### PR TITLE
Parse without use of regex to work around dependency conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,4 @@ keywords = ["riscv"]
 license = "ISC"
 
 [dependencies]
-regex = "1"
 lazy_static = "1"


### PR DESCRIPTION
The dependencies of the `regex` crate (especially `memchr`) clash with my runtime dependencies which need to be `no_std`. I don't think there's a general way to prevent feature clashes between build-time and run-time dependencies yet.

So the most straightforward workaround seems to be to write the parsing in this crate without relying on a regex. It hardly increases the length or complexity of the code.